### PR TITLE
Fix the maintainers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/event-model
+* @danielballan @mrakitin @stuartcampbell @tacaswell

--- a/README.md
+++ b/README.md
@@ -116,5 +116,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@conda-forge/event-model](https://github.com/conda-forge/event-model/)
+* [@danielballan](https://github.com/danielballan/)
+* [@mrakitin](https://github.com/mrakitin/)
+* [@stuartcampbell](https://github.com/stuartcampbell/)
+* [@tacaswell](https://github.com/tacaswell/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,4 +40,7 @@ about:
 
 extra:
   recipe-maintainers:
-    - conda-forge/event-model
+    - danielballan
+    - mrakitin
+    - stuartcampbell
+    - tacaswell


### PR DESCRIPTION
Per @CJ-Wright's request in https://github.com/conda-forge/event-model-feedstock/pull/20#issuecomment-541255356, here is an updated list of maintainers of this feedstock and other @conda-forge/event-model supported feedstocks.